### PR TITLE
Force std=c++11 so it build on macs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 **NOTE: This is currently under development.**
 
-A collection of utilities related to CTC, with the goal of being fast and highly flexible.  
+A collection of utilities related to CTC, with the goal of being fast and highly flexible.
 
 ## Features
 
@@ -19,15 +19,16 @@ A collection of utilities related to CTC, with the goal of being fast and highly
 ## Installation
 
 `ctclib` depends on [kpu/kenlm](https://github.com/kpu/kenlm).
-You must install the following libraries as KenLM dependencies.
+You must install the following tools and libraries as KenLM dependencies.
 
+- cmake
 - Boost
 - Eigen3
 
 For example, if you are using Ubuntu (or some Debian based Linux), you can install them by running the following command:
 
 ```sh
-apt install libboost-all-dev libeigen3-dev
+apt install cmake libboost-all-dev libeigen3-dev
 ```
 
 ### Use ctclib from Rust

--- a/ctclib-kenlm-sys/build.rs
+++ b/ctclib-kenlm-sys/build.rs
@@ -16,7 +16,7 @@ fn main() {
     }
 
     // CMake
-    let dst = Config::new(&kenlm_root).profile("Release").build();
+    let dst = Config::new(&kenlm_root).define("CMAKE_CXX_STANDARD", "11").profile("Release").build();
 
     // bindgen build
     let bindings = bindgen::Builder::default()


### PR DESCRIPTION
In order to build `kenlm` on modern macs `--std=c++11` must be explicitly enabled.

```console
$ clang --version
Apple clang version 15.0.0 (clang-1500.3.9.4)
```

I tried this patch on linux debian:11 and debian:12 and it doesn't cause regressions there.

While I was at it I noticed that the readme didn't mention the necessity of installing `cmake` which is required to build `kenlm`, so I updated the README.